### PR TITLE
Remove duplicated te inits

### DIFF
--- a/src/main/java/ironfurnaces/container/furnaces/BlockCopperFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockCopperFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockCopperFurnaceContainer extends BlockIronFurnaceContainerBase {
 
     public BlockCopperFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.COPPER_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockCopperFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockCrystalFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockCrystalFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockCrystalFurnaceContainer extends BlockIronFurnaceContainerBase 
 
     public BlockCrystalFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.CRYSTAL_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockCrystalFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockDiamondFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockDiamondFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockDiamondFurnaceContainer extends BlockIronFurnaceContainerBase 
 
     public BlockDiamondFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.DIAMOND_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockDiamondFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockEmeraldFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockEmeraldFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockEmeraldFurnaceContainer extends BlockIronFurnaceContainerBase 
 
     public BlockEmeraldFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.EMERALD_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockEmeraldFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockGoldFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockGoldFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockGoldFurnaceContainer extends BlockIronFurnaceContainerBase {
 
     public BlockGoldFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.GOLD_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockGoldFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockIronFurnaceContainer extends BlockIronFurnaceContainerBase {
 
     public BlockIronFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.IRON_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockIronFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainerBase.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainerBase.java
@@ -25,10 +25,10 @@ import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
 public abstract class BlockIronFurnaceContainerBase extends AbstractContainerMenu {
 
-    protected BlockIronFurnaceTileBase te;
-    protected Player playerEntity;
-    protected IItemHandler playerInventory;
-    protected final Level world;
+    private BlockIronFurnaceTileBase te;
+    private Player playerEntity;
+    private IItemHandler playerInventory;
+    private final Level world;
 
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockMillionFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockMillionFurnaceContainer.java
@@ -12,7 +12,6 @@ public class BlockMillionFurnaceContainer extends BlockIronFurnaceContainerBase 
 
     public BlockMillionFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.MILLION_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockMillionFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockNetheriteFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockNetheriteFurnaceContainer.java
@@ -13,7 +13,6 @@ public class BlockNetheriteFurnaceContainer extends BlockIronFurnaceContainerBas
 
     public BlockNetheriteFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.NETHERITE_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockNetheriteFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockObsidianFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockObsidianFurnaceContainer.java
@@ -14,7 +14,6 @@ public class BlockObsidianFurnaceContainer extends BlockIronFurnaceContainerBase
 
     public BlockObsidianFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.OBSIDIAN_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockObsidianFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/BlockSilverFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockSilverFurnaceContainer.java
@@ -12,7 +12,6 @@ public class BlockSilverFurnaceContainer extends BlockIronFurnaceContainerBase {
 
     public BlockSilverFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.SILVER_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockSilverFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/other/BlockAllthemodiumFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/other/BlockAllthemodiumFurnaceContainer.java
@@ -16,7 +16,6 @@ public class BlockAllthemodiumFurnaceContainer extends BlockIronFurnaceContainer
 
     public BlockAllthemodiumFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.ALLTHEMODIUM_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockAllthemodiumFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/other/BlockUnobtainiumFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/other/BlockUnobtainiumFurnaceContainer.java
@@ -14,7 +14,6 @@ public class BlockUnobtainiumFurnaceContainer extends BlockIronFurnaceContainerB
 
     public BlockUnobtainiumFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.UNOBTAINIUM_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockUnobtainiumFurnaceTile) world.getBlockEntity(pos);
     }
 
 

--- a/src/main/java/ironfurnaces/container/furnaces/other/BlockVibraniumFurnaceContainer.java
+++ b/src/main/java/ironfurnaces/container/furnaces/other/BlockVibraniumFurnaceContainer.java
@@ -12,7 +12,6 @@ public class BlockVibraniumFurnaceContainer extends BlockIronFurnaceContainerBas
 
     public BlockVibraniumFurnaceContainer(int windowId, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(Registration.VIBRANIUM_FURNACE_CONTAINER.get(), windowId, world, pos, playerInventory, player);
-        this.te = (BlockVibraniumFurnaceTile) world.getBlockEntity(pos);
     }
 
 


### PR DESCRIPTION
Avoids useless initializations of block tile entities.

Ensure this will no longer happen by encapsulating the member to the base class.